### PR TITLE
[WIFI-6170] Add OpenWifi Docker Compose deployment with PostgreSQL

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,6 +88,7 @@ COPY owsec.properties.tmpl /
 COPY wwwassets /dist/wwwassets
 COPY templates /dist/templates
 COPY docker-entrypoint.sh /
+COPY wait-for-postgres.sh /
 RUN wget https://raw.githubusercontent.com/Telecominfraproject/wlan-cloud-ucentral-deploy/main/docker-compose/certs/restapi-ca.pem \
     -O /usr/local/share/ca-certificates/restapi-ca-selfsigned.pem
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN addgroup -S "$OWSEC_USER" && \
 RUN mkdir /openwifi
 RUN mkdir -p "$OWSEC_ROOT" "$OWSEC_CONFIG" && \
     chown "$OWSEC_USER": "$OWSEC_ROOT" "$OWSEC_CONFIG"
-RUN apk add --update --no-cache librdkafka mariadb-connector-c libpq unixodbc su-exec gettext ca-certificates libcurl curl-dev bash jq curl
+RUN apk add --update --no-cache librdkafka mariadb-connector-c libpq unixodbc su-exec gettext ca-certificates libcurl curl-dev bash jq curl postgresql-client
 COPY --from=builder /owsec/cmake-build/owsec /openwifi/owsec
 COPY --from=builder /cppkafka/cmake-build/src/lib/* /lib/
 COPY --from=builder /poco/cmake-build/lib/* /lib/

--- a/wait-for-postgres.sh
+++ b/wait-for-postgres.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+# wait-for-postgres.sh
+
+set -e
+  
+host="$1"
+shift
+
+export PGUSER=$(grep 'storage.type.postgresql.username' $OWSEC_CONFIG/owsec.properties | awk -F '= ' '{print $2}')
+export PGPASSWORD=$(grep 'storage.type.postgresql.password' $OWSEC_CONFIG/owsec.properties | awk -F '= ' '{print $2}')
+  
+until psql -h "$host" -c '\q'; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+  
+>&2 echo "Postgres is up - executing command"
+
+if [ "$1" = '/openwifi/owsec' -a "$(id -u)" = '0' ]; then
+    if [ "$RUN_CHOWN" = 'true' ]; then
+      chown -R "$OWSEC_USER": "$OWSEC_ROOT" "$OWSEC_CONFIG"
+    fi
+    exec su-exec "$OWSEC_USER" "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
The microservices only initialize the DB when it is available on startup. Since Docker Compose doesn't wait for the DB container to be ready that can lead to empty databases. This script can be used as a workaround to wait for DB readiness.